### PR TITLE
Update BaseElite.cs

### DIFF
--- a/BaseAssetTypes/BaseElite.cs
+++ b/BaseAssetTypes/BaseElite.cs
@@ -166,14 +166,16 @@ namespace MysticsRisky2Utils.BaseAssetTypes
                 {
                     case 1:
                         HG.ArrayUtils.ArrayAppend(ref R2API.EliteAPI.VanillaEliteTiers[1].eliteTypes, customElite.eliteDef);
+                        HG.ArrayUtils.ArrayAppend(ref R2API.EliteAPI.VanillaEliteTiers[4].eliteTypes, customElite.eliteDef);
                         break;
                     case 2:
-                        HG.ArrayUtils.ArrayAppend(ref R2API.EliteAPI.VanillaEliteTiers[4].eliteTypes, customElite.eliteDef);
+                        HG.ArrayUtils.ArrayAppend(ref R2API.EliteAPI.VanillaEliteTiers[5].eliteTypes, customElite.eliteDef);
                         break;
                 }
                 if (customElite.isHonor)
                 {
                     HG.ArrayUtils.ArrayAppend(ref R2API.EliteAPI.VanillaEliteTiers[2].eliteTypes, customElite.eliteDef);
+                    HG.ArrayUtils.ArrayAppend(ref R2API.EliteAPI.VanillaEliteTiers[3].eliteTypes, customElite.eliteDef);
                 }
             }
         }


### PR DESCRIPTION
simple fix for elite tiers being incorrect

pillaging elites seem to be in their own tier still, so this change won't fix those